### PR TITLE
feat: support laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.3 | ^8.4 | ^8.5",
-        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+        "laravel/framework": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.15",
         "celtic/lti": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
         }
     ],
     "require": {
-        "php": "^8.1 | ^8.2 | ^8.3 | ^8.4",
-        "laravel/framework": "^10.0|^11.0|^12.0",
+        "php": "^8.3 | ^8.4 | ^8.5",
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.15",
         "celtic/lti": "^5.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "larastan/larastan": "^3.0",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^11.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": ">=10.0"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Widen version constraints to allow laravel/framework ^13.0, orchestra/testbench ^11.0, and phpunit/phpunit ^12.0, matching the pattern used for the earlier laravel/12 support.

## Description

Bumped composer packages to be able to support laravel 13

## Motivation and context

Ability to support laravel 13

If it fixes an open issue, please link to the issue here (if you write `fixes #num`
or `closes #num`, the issue will be automatically closed when the pull is accepted.)

## How has this been tested?
Let composer validate the new versions

## Screenshots (if appropriate)

## Types of changes


## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
